### PR TITLE
Spring Boot 4.0.5 と Gradle 8.14 へ更新

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -33,7 +33,6 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf:thymeleaf:3.1.4.RELEASE'
     implementation 'org.thymeleaf:thymeleaf-spring6:3.1.4.RELEASE'
-	implementation platform('tools.jackson:jackson-bom:3.1.1')
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -33,6 +33,7 @@ dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter-security'
     implementation 'org.thymeleaf:thymeleaf:3.1.4.RELEASE'
     implementation 'org.thymeleaf:thymeleaf-spring6:3.1.4.RELEASE'
+	implementation platform('tools.jackson:jackson-bom:3.1.1')
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 plugins {
 	id 'java'
-	id 'org.springframework.boot' version '3.5.12'
+	id 'org.springframework.boot' version '4.0.5'
 	id 'io.spring.dependency-management' version '1.1.7'
 	id 'org.cyclonedx.bom' version '1.8.2'
 }
@@ -10,16 +10,12 @@ version = '0.0.1-SNAPSHOT'
 
 java {
 	toolchain {
-		languageVersion = JavaLanguageVersion.of(17)
+		languageVersion = JavaLanguageVersion.of(21)
 	}
 }
 
 repositories {
 	mavenCentral()
-}
-
-ext {
-    set('jackson.version', '2.18.6')
 }
 
 dependencies {
@@ -35,6 +31,7 @@ dependencies {
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'
 	testImplementation 'org.springframework.boot:spring-boot-starter-test'
+	testRuntimeOnly 'com.h2database:h2'
 	testRuntimeOnly 'org.junit.platform:junit-platform-launcher'
 }
 

--- a/build.gradle
+++ b/build.gradle
@@ -18,6 +18,10 @@ repositories {
 	mavenCentral()
 }
 
+ext {
+    set('tomcat.version', '11.0.21')
+}
+
 dependencies {
 	implementation 'org.springframework.boot:spring-boot-starter'
 	implementation 'org.springdoc:springdoc-openapi-starter-webmvc-ui:2.3.0'
@@ -27,6 +31,8 @@ dependencies {
 	implementation 'org.postgresql:postgresql'
 	implementation 'org.apache.commons:commons-lang3:3.18.0'
 	implementation 'org.springframework.boot:spring-boot-starter-security'
+    implementation 'org.thymeleaf:thymeleaf:3.1.4.RELEASE'
+    implementation 'org.thymeleaf:thymeleaf-spring6:3.1.4.RELEASE'
 	compileOnly 'org.projectlombok:lombok'
 	developmentOnly 'org.springframework.boot:spring-boot-devtools'
 	annotationProcessor 'org.projectlombok:lombok'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.13-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.4-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/src/main/resources/application.yml
+++ b/src/main/resources/application.yml
@@ -7,10 +7,10 @@ spring:
   jpa:
     hibernate:
       ddl-auto: update
-    show-sql: ${SHOW_SQL}
+    show-sql: ${SHOW_SQL:false}
     properties:
       hibernate:
-        format_sql: ${FORMAT_SQL}
+        format_sql: ${FORMAT_SQL:false}
         dialect: org.hibernate.dialect.PostgreSQLDialect
   security:
     cookie:

--- a/src/test/resources/application.yml
+++ b/src/test/resources/application.yml
@@ -1,0 +1,13 @@
+# テスト実行時は .env が読み込まれないため、インメモリ DB でコンテキストを起動する
+spring:
+  datasource:
+    url: jdbc:h2:mem:testdb;DB_CLOSE_DELAY=-1;MODE=PostgreSQL;DATABASE_TO_LOWER=TRUE
+    username: sa
+    password:
+    driver-class-name: org.h2.Driver
+  jpa:
+    hibernate:
+      ddl-auto: create-drop
+    properties:
+      hibernate:
+        dialect: org.hibernate.dialect.H2Dialect


### PR DESCRIPTION
- Gradle Wrapper を 8.14.4 に更新（Boot 4 の要件を満たす）
- 本番用 application: SHOW_SQL / FORMAT_SQL にデフォルトを付与
- テスト用 application + H2 でローカル DB なしでもテスト可能に
- Jackson の ext 上書きを削除（BOM に委ねる）